### PR TITLE
feat: vision cone

### DIFF
--- a/src/minimap.c
+++ b/src/minimap.c
@@ -6,36 +6,49 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 15:20:28 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/11/16 12:52:51 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/11/17 12:55:37 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "cub3D.h"
 
 
-void draw_cone(t_macro *macro) {
+void draw_vision_cone(t_macro *macro)
+{
+    int x;
+    int draw_x, draw_y;
+    float ray_length;
+    int max_distance = 64;
 
-	// int i = 0;
-	// while(i < 50)
-	// {
-	// 	mlx_put_pixel(macro->scene_i, macro->start_x * 32 + 15 + i, macro->start_y * 32 + 15 + i, 0xffff00);
-	// 	mlx_put_pixel(macro->scene_i, macro->start_x * 32 + 15 + i, macro->start_y * 32 + 15 - i, 0xffff00);
-	// 	i++;
-	// }
-    float angle_step = 0.001f;  // Adjust this for smoothness of the filled cone
-    float max_distance = 70;   // Maximum distance of the cone's vision
-    float vision_angle = M_PI / 4;  // Define the cone's angle (e.g., 45 degrees)
+    x = 0;
+    while (x < macro->width)
+    {
+        macro->camera_x = 2 * x / (double)macro->width - 1;
+        macro->ray_dir_x = cos(macro->play_angle) + macro->camera_x * cos(macro->play_angle + M_PI / 2);
+        macro->ray_dir_y = sin(macro->play_angle) + macro->camera_x * sin(macro->play_angle + M_PI / 2);
+        
+        ray_length = macro->perp_wall_dist * BLOCK;
+        ray_length = fmin(ray_length, max_distance);
 
-    // Loop over angles from the left edge to the right edge of the cone
-    for (float angle = -vision_angle / 2; angle <= vision_angle / 2; angle += angle_step) {
-        // Draw a line from the center to the maximum distance at this angle
-        for (float dist = 0; dist <= max_distance; dist++) {
-            int x = macro->start_x * 32 + 15 + (int)(cos(angle) * dist);
-            int y = macro->start_y * 32 + 15 + (int)(sin(angle) * dist);
-            mlx_put_pixel(macro->scene_i, x, y, 0xFFFF00);  // Draw pixel in the cone
+        float dist = 0.0f;
+        while (dist <= ray_length)
+        {
+            draw_x = macro->pos_pl_x + (BLOCK / 2) + (int)(macro->ray_dir_x * dist);
+            draw_y = macro->pos_pl_y + (BLOCK / 2) + (int)(macro->ray_dir_y * dist);
+            
+            if (draw_x >= 0 && draw_x < (int)macro->map->w_map * BLOCK &&
+                draw_y >= 0 && draw_y < (int)macro->map->h_map * BLOCK)
+            {
+                int alpha = 255 - (int)((dist / ray_length) * 200);
+                int color = (255 << 24) | (255 << 16) | (255 << 8) | alpha; // Yellow with fade
+                mlx_put_pixel(macro->mini_i, draw_x, draw_y, color);
+            }
+            dist += 0.5f;
         }
+        x += 4;
     }
 }
+
 
 int get_rgba(int r, int g, int b, int a) {
   return (r << 24 | g << 16 | b << 8 | a);
@@ -113,4 +126,5 @@ void draw_minimap(t_macro *macro)
     correct_player_pos_in_edge(macro, &adj_x, &adj_y);
     printf("player position: %d, %d\n", adj_x, adj_y);
 	put_img_to_img(macro->mini_i, macro->minimap->player, adj_x, adj_y);
+  draw_vision_cone(macro);
 }

--- a/src/minimap.c
+++ b/src/minimap.c
@@ -6,112 +6,110 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 15:20:28 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/11/17 13:26:22 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/11/17 14:04:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "cub3D.h"
 
 
+void initialize_vision_ray(t_macro *macro, int x, double *ray_dir_x, double *ray_dir_y)
+{
+    double camera_x;
+    float center_x;
+    float center_y;
+    
+    center_x = macro->pos_pl_x + BLOCK / 2;
+    center_y = macro->pos_pl_y + BLOCK / 2;
+    camera_x = 2 * x / (double)macro->width - 1;
+    *ray_dir_x = cos(macro->play_angle) + camera_x * cos(macro->play_angle + M_PI / 2);
+    *ray_dir_y = sin(macro->play_angle) + camera_x * sin(macro->play_angle + M_PI / 2);
+    macro->map_x = (int)(center_x / BLOCK);
+    macro->map_y = (int)(center_y / BLOCK);
+    macro->delta_dist_x = fabs(1 / *ray_dir_x);
+    macro->delta_dist_y = fabs(1 / *ray_dir_y);
+    macro->hit = 0;
+}
+
+void calculate_ray_steps(t_macro *macro, double ray_dir_x, double ray_dir_y)
+{
+    float center_x;
+    float center_y;
+    
+    center_x = macro->pos_pl_x + BLOCK / 2;
+    center_y = macro->pos_pl_y + BLOCK / 2;
+    if (ray_dir_x < 0)
+    {
+        macro->step_x = -1;
+        macro->side_dist_x = (center_x / BLOCK - macro->map_x) * macro->delta_dist_x;
+    }
+    else
+    {
+        macro->step_x = 1;
+        macro->side_dist_x = (macro->map_x + 1.0 - center_x / BLOCK) * macro->delta_dist_x;
+    }
+    if (ray_dir_y < 0)
+    {
+        macro->step_y = -1;
+        macro->side_dist_y = (center_y / BLOCK - macro->map_y) * macro->delta_dist_y;
+    }
+    else
+    {
+        macro->step_y = 1;
+        macro->side_dist_y = (macro->map_y + 1.0 - center_y / BLOCK) * macro->delta_dist_y;
+    }
+}
+
+void draw_ray(t_macro *macro, float ray_length, double ray_dir_x, double ray_dir_y)
+{
+    float dist;
+    int draw_x;
+    int draw_y;
+    float center_x;
+    float center_y;
+
+    dist = 0.0f;
+    center_x = macro->pos_pl_x + BLOCK / 2;
+    center_y = macro->pos_pl_y + BLOCK / 2;
+    while (dist <= ray_length)
+    {
+        draw_x = center_x + (int)(ray_dir_x * dist);
+        draw_y = center_y + (int)(ray_dir_y * dist);
+        if (draw_x >= 0 && draw_x < (int)macro->map->w_map * 32 &&
+            draw_y >= 0 && draw_y < (int)macro->map->h_map * 32)
+        {
+            mlx_put_pixel(macro->mini_i, draw_x, draw_y, 
+                get_rgba(255, 255, 255, 255));
+        }
+        dist += 0.5f;
+    }
+}
+
 void draw_vision_cone(t_macro *macro)
 {
     int x;
-    int draw_x, draw_y;
     float ray_length;
-    
-    
-    double camera_x;
-    double ray_dir_x, ray_dir_y;
-    int map_x, map_y;
-    double side_dist_x, side_dist_y;
-    double delta_dist_x, delta_dist_y;
-    int step_x, step_y;
-    int hit, side;
-    
-    
-    float center_x = macro->pos_pl_x + BLOCK / 2;
-    float center_y = macro->pos_pl_y + BLOCK / 2;
+    double ray_dir_x;
+    double ray_dir_y;
+    float center_x;
+    float center_y;
     
     x = 0;
+    center_x = macro->pos_pl_x + BLOCK / 2;
+    center_y = macro->pos_pl_y + BLOCK / 2;
     while (x < macro->width)
     {
+        initialize_vision_ray(macro, x, &ray_dir_x, &ray_dir_y);
+        calculate_ray_steps(macro, ray_dir_x, ray_dir_y);
+        perform_dda(macro);
         
-        camera_x = 2 * x / (double)macro->width - 1;
-        ray_dir_x = cos(macro->play_angle) + camera_x * cos(macro->play_angle + M_PI / 2);
-        ray_dir_y = sin(macro->play_angle) + camera_x * sin(macro->play_angle + M_PI / 2);
-
-        
-        map_x = (int)(center_x / BLOCK);
-        map_y = (int)(center_y / BLOCK);
-        delta_dist_x = fabs(1 / ray_dir_x);
-        delta_dist_y = fabs(1 / ray_dir_y);
-        hit = 0;
-
-        
-        if (ray_dir_x < 0)
-        {
-            step_x = -1;
-            side_dist_x = (center_x / BLOCK - map_x) * delta_dist_x;
-        }
+        if (macro->side == 0)
+            ray_length = (macro->map_x - center_x / BLOCK + 
+                (1 - macro->step_x) / 2) / ray_dir_x * BLOCK;
         else
-        {
-            step_x = 1;
-            side_dist_x = (map_x + 1.0 - center_x / BLOCK) * delta_dist_x;
-        }
-        if (ray_dir_y < 0)
-        {
-            step_y = -1;
-            side_dist_y = (center_y / BLOCK - map_y) * delta_dist_y;
-        }
-        else
-        {
-            step_y = 1;
-            side_dist_y = (map_y + 1.0 - center_y / BLOCK) * delta_dist_y;
-        }
-
-        
-        while (hit == 0)
-        {
-            if (side_dist_x < side_dist_y)
-            {
-                side_dist_x += delta_dist_x;
-                map_x += step_x;
-                side = 0;
-            }
-            else
-            {
-                side_dist_y += delta_dist_y;
-                map_y += step_y;
-                side = 1;
-            }
-            if (macro->map->map[map_y][map_x] == '1')
-                hit = 1;
-        }
-
-        
-        if (side == 0)
-            ray_length = (map_x - center_x / BLOCK + 
-                (1 - step_x) / 2) / ray_dir_x * BLOCK;
-        else
-            ray_length = (map_y - center_y / BLOCK + 
-                (1 - step_y) / 2) / ray_dir_y * BLOCK;
-
-        
-        float dist = 0.0f;
-        while (dist <= ray_length)
-        {
-            draw_x = center_x + (int)(ray_dir_x * dist);
-            draw_y = center_y + (int)(ray_dir_y * dist);
-            
-            if (draw_x >= 0 && draw_x < (int)macro->map->w_map * 32 &&
-                draw_y >= 0 && draw_y < (int)macro->map->h_map * 32)
-            {
-                int alpha = 255;
-                int color = (255 << 24) | (255 << 16) | (255 << 8) | alpha;
-                mlx_put_pixel(macro->mini_i, draw_x, draw_y, color);
-            }
-            dist += 0.5f;
-        }
+            ray_length = (macro->map_y - center_y / BLOCK + 
+                (1 - macro->step_y) / 2) / ray_dir_y * BLOCK;
+        draw_ray(macro, ray_length, ray_dir_x, ray_dir_y);
         x += 1;
     }
 }

--- a/src/player.c
+++ b/src/player.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   player.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/06 07:01:36 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/11/12 07:07:05 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/11/18 09:43:47 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,36 +35,34 @@ void move(t_macro *macro)
    
     if (macro->key_w)
     {
-        x+= WALK_SPEED * cos(macro->play_angle);
-        y += WALK_SPEED * sin(macro->play_angle);
+        x+= (int)(WALK_SPEED * cos(macro->play_angle));
+        y += (int)(WALK_SPEED * sin(macro->play_angle));
     }
     if (macro->key_a)
     {
-        x-= WALK_SPEED * cos(macro->play_angle + M_PI / 2);
-        y -= WALK_SPEED * sin(macro->play_angle + M_PI / 2);
+        x-= (int)(WALK_SPEED * cos(macro->play_angle + M_PI / 2));
+        y -= (int)(WALK_SPEED * sin(macro->play_angle + M_PI / 2));
     }
     if (macro->key_s)
     {
-        x-= WALK_SPEED * cos(macro->play_angle);
-        y -= WALK_SPEED * sin(macro->play_angle);
+        x-= (int)(WALK_SPEED * cos(macro->play_angle));
+        y -= (int)(WALK_SPEED * sin(macro->play_angle));
     }
     if (macro->key_d)
     {
-        x+= WALK_SPEED * cos(macro->play_angle + M_PI / 2);
-        y += WALK_SPEED * sin(macro->play_angle + M_PI / 2);
+        x+= (int)(WALK_SPEED * cos(macro->play_angle + M_PI / 2));
+        y += (int)(WALK_SPEED * sin(macro->play_angle + M_PI / 2));
     }
-    if (macro->key_left)
-    {
-        macro->play_angle -= ROT_SPEED;
-        if (macro->play_angle < 0)
-            macro->play_angle += 2 * M_PI;
-    }
-    if (macro->key_right)
-    {
-        macro->play_angle += ROT_SPEED;
-        if (macro->play_angle > 2 * M_PI)
-            macro->play_angle -= 2 * M_PI;  
-    }
+if (macro->key_left)
+{
+    macro->play_angle -= ROT_SPEED;
+    macro->play_angle = fmod(macro->play_angle + 2 * M_PI, 2 * M_PI);
+}
+if (macro->key_right)
+{
+    macro->play_angle += ROT_SPEED;
+    macro->play_angle = fmod(macro->play_angle, 2 * M_PI);
+}
     stop_at_wall(macro, x, y);
 }
 


### PR DESCRIPTION
Add a vision cone to the player's movement.

The cone extends as much as the player can view and stops at the walls it encounters.